### PR TITLE
#82 - Markdown rendering issue

### DIFF
--- a/src/components/JobContent.astro
+++ b/src/components/JobContent.astro
@@ -9,65 +9,6 @@
   width: 100%;
   max-width: 680px;
   margin: 5.8rem auto 0;
-
-  h3,
-  h4 {
-    color: $dark-green;
-  }
-
-  h3 {
-    font-size: 28px;
-    margin-bottom: 2.5rem;
-  }
-
-  h4 {
-    font-size: 20px;
-    margin: 3rem 0 2rem;
-  }
-
-  p {
-    margin-bottom: 1rem;
-    color: $grey;
-
-    &:has(+ h3) {
-      margin-bottom: 3rem;
-    }
-  }
-
-  a {
-    color: $blue;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-  
-  ul,
-  ol {
-    margin-left: 1.5rem;
-    margin-bottom: 2rem;
-
-    li {
-      color: $grey;
-      margin-bottom: 1rem;
-    }
-  }
-
-  ul {
-    list-style-type: disc;
-  }
-
-  ol {
-    list-style-position: outside;
-  }
-
-  pre:has(code) {
-    padding: 1.25rem 0.75rem;
-
-    .line {
-      line-height: 1.35;
-      letter-spacing: 0.25px;
-    }
-  }
+  @include markdown-style;
 }
 </style>

--- a/src/components/JobContent.astro
+++ b/src/components/JobContent.astro
@@ -17,17 +17,21 @@
 
   h3 {
     font-size: 28px;
-    margin-bottom: 1rem;
+    margin-bottom: 2.5rem;
   }
 
   h4 {
     font-size: 20px;
-    margin: 2rem 0 1rem;
+    margin: 3rem 0 2rem;
   }
 
   p {
     margin-bottom: 1rem;
     color: $grey;
+
+    &:has(+ h3) {
+      margin-bottom: 3rem;
+    }
   }
 
   a {
@@ -37,15 +41,32 @@
       text-decoration: underline;
     }
   }
-
-  ul {
-    list-style-type: disc;
+  
+  ul,
+  ol {
     margin-left: 1.5rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem;
 
     li {
       color: $grey;
-      margin-bottom: 0.5rem;
+      margin-bottom: 1rem;
+    }
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-position: outside;
+  }
+
+  pre:has(code) {
+    padding: 1.25rem 0.75rem;
+
+    .line {
+      line-height: 1.35;
+      letter-spacing: 0.25px;
     }
   }
 }

--- a/src/content/jobs/designer.md
+++ b/src/content/jobs/designer.md
@@ -31,3 +31,18 @@ To apply:
 3. Install [Keybase](https://keybase.io/) and send a copy of that message to [https://keybase.io/greg](https://keybase.io/greg)
 
 Make sure to do all 3 steps if you'd like to hear back from us.
+
+### Code fences
+
+```js
+export async function getStaticPaths() {
+  const jobs = sortedPosts(await Astro.glob('../../content/jobs/*.{md,mdx}'))
+  return jobs.map(job => {
+    // Use the permalink value defined in the frontmatter as the slug
+    return {
+      params: { job: job.frontmatter.permalink },
+      props: job
+    }
+  })
+}
+```

--- a/src/content/jobs/designer.md
+++ b/src/content/jobs/designer.md
@@ -31,18 +31,3 @@ To apply:
 3. Install [Keybase](https://keybase.io/) and send a copy of that message to [https://keybase.io/greg](https://keybase.io/greg)
 
 Make sure to do all 3 steps if you'd like to hear back from us.
-
-### Code fences
-
-```js
-export async function getStaticPaths() {
-  const jobs = sortedPosts(await Astro.glob('../../content/jobs/*.{md,mdx}'))
-  return jobs.map(job => {
-    // Use the permalink value defined in the frontmatter as the slug
-    return {
-      params: { job: job.frontmatter.permalink },
-      props: job
-    }
-  })
-}
-```

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,0 +1,11 @@
+$white: #f5f5f5;
+$background-grey: #eeeeee;
+$black: #141414;
+$grey: #5a5a5a;
+$grey_1: #888888;
+$grey_2: #9a9a9a;
+$grey_3: #dbdbdb;
+$green: #27ae60;
+$dark-green: #0C6130;
+$blue: #1479DE;
+$blue_1: #105EAA;

--- a/src/styles/_markdown_style.scss
+++ b/src/styles/_markdown_style.scss
@@ -1,0 +1,90 @@
+@use "colors" as *;
+
+@mixin markdown-style {
+  h3,
+  h4 {
+    color: $dark-green;
+  }
+
+  h3 {
+    font-size: 28px;
+    margin-bottom: 2.5rem;
+  }
+
+  h4 {
+    font-size: 20px;
+    margin: 3rem 0 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: $grey;
+
+    &:has(+ h3) {
+      margin-bottom: 3rem;
+    }
+  }
+
+  a {
+    color: $blue;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ul,
+  ol {
+    margin-left: 1.5rem;
+    margin-bottom: 2rem;
+
+    li {
+      color: $grey;
+      margin-bottom: 1rem;
+    }
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-position: outside;
+  }
+
+  pre:has(code) {
+    padding: 1.25rem 0.75rem;
+
+    .line {
+      line-height: 1.35;
+      letter-spacing: 0.5px;
+    }
+  }
+
+  blockquote {
+    position: relative;
+    padding: 0.5rem 0 0.5rem 1rem;
+    margin: 0;
+    word-break: break-word;
+
+    p {
+      width: 100%;
+      margin-bottom: 0;
+      font-style: italic;
+      font-size: 0.9em;
+      color: $grey_1;
+      word-break: break-word;
+    }
+
+    &::before {
+      content: "";
+      display: block;
+      position: absolute;
+      left: 0;
+      width: 4px;
+      top: 0;
+      bottom: 0;
+      background-color: $grey_3;
+    }
+  }
+}

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -37,7 +37,7 @@ body {
 	line-height: 1;
 }
 
-ol, ul {
+ul {
 	list-style: none;
 }
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,13 +1,5 @@
-$white: #f5f5f5;
-$background-grey: #eeeeee;
-$black: #141414;
-$grey: #5a5a5a;
-$grey_1: #888888;
-$grey_2: #9a9a9a;
-$green: #27ae60;
-$dark-green: #0C6130;
-$blue: #1479DE;
-$blue_1: #105EAA;
+@forward "colors";
+@forward "markdown_style";
 
 @mixin css3($property, $value) {
     @each $prefix in -webkit-, -moz-, -ms-, -o-, '' {


### PR DESCRIPTION
closes #82 

**[ Fix for `<ol></ol>` ]**

<img src='https://github.com/user-attachments/assets/24a78930-48ad-4761-8404-77942cdcb3e2' width='480'>

<br><br>

Below two(blockquote and code-fence elements) are not currently used anywhere in the website but added the styles for them anyways. (Please let me know if we want them to be styled otherwise.)

**[ Adding styles for `<code>` ]**

<img width="550" alt="code-fence-fix" src="https://github.com/user-attachments/assets/eddfe72e-c407-4937-82bb-6179c068f94f" />

<br><br>

**[ Adding styles for `<blockquote>` ]**

<img width="550" alt="blockquote-fix" src="https://github.com/user-attachments/assets/8c5b3926-70eb-4011-97a9-543b77e739e9" />
